### PR TITLE
Add name length validation to asset and asset_relation models.

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -15,6 +15,7 @@ class Asset < ActiveRecord::Base
   has_many :asset_geometries, :dependent => :destroy
 
   validates_presence_of :name, :asset_type_id, :type
+  validates_length_of :name, :maximum => 255
   before_validation_on_create :set_asset_type
   after_update :uhook_after_update
   attr_accessor :cloned_from

--- a/app/models/asset_relation.rb
+++ b/app/models/asset_relation.rb
@@ -3,6 +3,7 @@ class AssetRelation < ActiveRecord::Base
   belongs_to :related_object, :polymorphic => true
 
   validates_presence_of :asset
+  validates_length_of :name, :maximum => 255
 
   before_create :set_attribute_values
 


### PR DESCRIPTION
https://trello.com/c/vX2Msoqu/528-errbit-activerecord-statementinvalid-pgerror-error-value-too-long-for-type-character-varying-255
